### PR TITLE
Complete README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,3 +34,10 @@ To build `example.proto` and `feature.proto` into Go source code:
 protoc --go_out=/go/src -I tensorflow tensorflow/tensorflow/core/example/feature.proto 
 protoc --go_out=/go/src -I tensorflow tensorflow/tensorflow/core/example/example.proto
 ```
+
+To run the Go protobuf serialization benchmark:
+
+```bash
+go test -bench=.
+```
+


### PR DESCRIPTION
Following the README.md, we can run the Python and Go protobuf serialization benchmarks.

```
tf-docker /go/src/github.com/wangkuiyi/rpc-benchmark > python protobuf-serialize.py 
1.3624762810068205
tf-docker /go/src/github.com/wangkuiyi/rpc-benchmark > go test -bench=.
goos: linux
goarch: amd64
pkg: github.com/wangkuiyi/rpc-benchmark
BenchmarkSerialize-3   	  300000	      3749 ns/op
PASS
ok  	github.com/wangkuiyi/rpc-benchmark	1.183s
```

The Python benchmark takes 1.364567 seconds to serialize 10,000 messages, that is, 13,645.67 ns/op.

The Go benchmark shows 3,749 ns/op.

The Python serialization takes much more time than the Go version.